### PR TITLE
feat: add self-hosted priority endpoints config field

### DIFF
--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -452,10 +452,20 @@ class SettingsPage extends ConsumerWidget {
         title: title,
         initialRepos: endpoints,
         onSave: (updated) {
-          final current = ref.read(configProvider).value ?? {};
-          final newConfig = Map<String, dynamic>.from(current)
-            ..[configKey] = updated;
-          ref.read(configProvider.notifier).save(newConfig);
+          try {
+            final current = ref.read(configProvider).value ?? {};
+            final newConfig = Map<String, dynamic>.from(current)
+              ..[configKey] = updated;
+            ref.read(configProvider.notifier).save(newConfig);
+          } catch (e) {
+            if (!context.mounted) return;
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Could not save endpoints: $e'),
+                backgroundColor: Colors.red.shade700,
+              ),
+            );
+          }
         },
       ),
     );

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../providers/config_provider.dart';
 import '../providers/core_provider.dart';
 import '../providers/download_options_provider.dart';
 import '../providers/theme_provider.dart';
@@ -41,6 +42,7 @@ class SettingsPage extends ConsumerWidget {
     final accentColor = ref.watch(accentColorProvider);
     final downloadDir = ref.watch(downloadDirProvider);
     final dlOptions = ref.watch(downloadOptionsProvider);
+    final config = ref.watch(configProvider).value ?? {};
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
@@ -111,6 +113,50 @@ class SettingsPage extends ConsumerWidget {
             subtitle: Text(dlOptions['PreferredSource'] as String? ?? 'Tidal'),
             trailing: const Icon(Icons.chevron_right),
             onTap: () => _showPreferredSourcePicker(context, ref, dlOptions),
+          ),
+
+          SectionHeader(title: 'Self-Hosted Endpoints'),
+          ListTile(
+            leading: const Icon(Icons.dns),
+            title: const Text('Tidal priority endpoints'),
+            subtitle: Text(
+              _endpointsSubtitle(config['tidalPriorityEndpoints']),
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => _showEndpointsManager(
+              context,
+              ref,
+              'tidalPriorityEndpoints',
+              'Tidal Priority Endpoints',
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.dns),
+            title: const Text('Qobuz priority endpoints'),
+            subtitle: Text(
+              _endpointsSubtitle(config['qobuzPriorityEndpoints']),
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => _showEndpointsManager(
+              context,
+              ref,
+              'qobuzPriorityEndpoints',
+              'Qobuz Priority Endpoints',
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.dns),
+            title: const Text('Amazon priority endpoints'),
+            subtitle: Text(
+              _endpointsSubtitle(config['amazonPriorityEndpoints']),
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => _showEndpointsManager(
+              context,
+              ref,
+              'amazonPriorityEndpoints',
+              'Amazon Priority Endpoints',
+            ),
           ),
 
           ListTile(
@@ -382,6 +428,39 @@ class SettingsPage extends ConsumerWidget {
     );
   }
 
+  static String _endpointsSubtitle(dynamic list) {
+    final count = list is List ? list.length : 0;
+    return count == 0
+        ? 'Public pool only'
+        : '$count self-hosted endpoint${count == 1 ? '' : 's'}';
+  }
+
+  void _showEndpointsManager(
+    BuildContext context,
+    WidgetRef ref,
+    String configKey,
+    String title,
+  ) {
+    final config = ref.read(configProvider).value ?? {};
+    final endpoints = List<String>.from(
+      config[configKey] as List<dynamic>? ?? [],
+    );
+
+    showDialog(
+      context: context,
+      builder: (ctx) => _RepoManagerDialog(
+        title: title,
+        initialRepos: endpoints,
+        onSave: (updated) {
+          final current = ref.read(configProvider).value ?? {};
+          final newConfig = Map<String, dynamic>.from(current)
+            ..[configKey] = updated;
+          ref.read(configProvider.notifier).save(newConfig);
+        },
+      ),
+    );
+  }
+
   static String _folderTemplateLabel(String template) {
     for (final (label, value) in _folderTemplates) {
       if (value == template) return label;
@@ -421,10 +500,15 @@ class SettingsPage extends ConsumerWidget {
 }
 
 class _RepoManagerDialog extends StatefulWidget {
+  final String title;
   final List<String> initialRepos;
   final ValueChanged<List<String>> onSave;
 
-  const _RepoManagerDialog({required this.initialRepos, required this.onSave});
+  const _RepoManagerDialog({
+    this.title = 'Extension Repositories',
+    required this.initialRepos,
+    required this.onSave,
+  });
 
   @override
   State<_RepoManagerDialog> createState() => _RepoManagerDialogState();
@@ -456,7 +540,7 @@ class _RepoManagerDialogState extends State<_RepoManagerDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('Extension Repositories'),
+      title: Text(widget.title),
       content: SizedBox(
         width: double.maxFinite,
         child: Column(

--- a/test/config_provider_test.dart
+++ b/test/config_provider_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flacidal_mobile/providers/config_provider.dart';
+
+// Like widget_test.dart, this exercises ConfigNotifier, which calls into
+// FlacCore (Go FFI) via flacCoreProvider. FlacCore.instance is a singleton
+// with a private constructor (see lib/core/flac_core.dart) that can only be
+// brought up by FlacCore.instance.init(dataDir) — done once in main.dart at
+// app startup — so it can't be faked or overridden here without a real
+// native library loaded. Run on a real device/emulator:
+//   flutter test --device-id=<device>
+
+void main() {
+  test('ConfigNotifier round-trips the priority-endpoints keys', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final current = container.read(configProvider).value ?? {};
+    final updated = Map<String, dynamic>.from(current)
+      ..['tidalPriorityEndpoints'] = ['https://tidal.example.com']
+      ..['qobuzPriorityEndpoints'] = ['https://qobuz.example.com']
+      ..['amazonPriorityEndpoints'] = ['https://amazon.example.com'];
+
+    container.read(configProvider.notifier).save(updated);
+
+    final result = container.read(configProvider).value ?? {};
+    expect(result['tidalPriorityEndpoints'], ['https://tidal.example.com']);
+    expect(result['qobuzPriorityEndpoints'], ['https://qobuz.example.com']);
+    expect(result['amazonPriorityEndpoints'], ['https://amazon.example.com']);
+  });
+}

--- a/test/config_provider_test.dart
+++ b/test/config_provider_test.dart
@@ -8,25 +8,49 @@ import 'package:flacidal_mobile/providers/config_provider.dart';
 // with a private constructor (see lib/core/flac_core.dart) that can only be
 // brought up by FlacCore.instance.init(dataDir) — done once in main.dart at
 // app startup — so it can't be faked or overridden here without a real
-// native library loaded. Run on a real device/emulator:
-//   flutter test --device-id=<device>
+// native library loaded.
+//
+// Confirmed unrunnable as a plain `flutter test` unit test, not just
+// unverified: ConfigNotifier.save() (config_provider.dart) has no try/catch
+// around core.saveConfig(), and FlacCore._ensureInitialized() throws
+// FlacCoreException(NOT_INITIALIZED) whenever init() hasn't run — which it
+// hasn't here. init() itself needs (a) path_provider's
+// getApplicationDocumentsDirectory(), a platform-channel plugin that needs a
+// running app context (main.dart:29-31), and (b) flac_ffi.dart's
+// DynamicLibrary.open('libflacidal.so')/DynamicLibrary.process(), a native
+// library only resolvable from inside an installed app bundle on a real
+// device/emulator (Android/iOS) — not from a bare host `flutter test`
+// process. Wiring both up is real integration-test infrastructure work,
+// out of scope for this task. Skipped rather than faked or silently left
+// red — see task-11-report.md for details.
 
 void main() {
-  test('ConfigNotifier round-trips the priority-endpoints keys', () {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+  test(
+    'ConfigNotifier round-trips the priority-endpoints keys',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-    final current = container.read(configProvider).value ?? {};
-    final updated = Map<String, dynamic>.from(current)
-      ..['tidalPriorityEndpoints'] = ['https://tidal.example.com']
-      ..['qobuzPriorityEndpoints'] = ['https://qobuz.example.com']
-      ..['amazonPriorityEndpoints'] = ['https://amazon.example.com'];
+      final current = container.read(configProvider).value ?? {};
+      final updated = Map<String, dynamic>.from(current)
+        ..['tidalPriorityEndpoints'] = ['https://tidal.example.com']
+        ..['qobuzPriorityEndpoints'] = ['https://qobuz.example.com']
+        ..['amazonPriorityEndpoints'] = ['https://amazon.example.com'];
 
-    container.read(configProvider.notifier).save(updated);
+      container.read(configProvider.notifier).save(updated);
 
-    final result = container.read(configProvider).value ?? {};
-    expect(result['tidalPriorityEndpoints'], ['https://tidal.example.com']);
-    expect(result['qobuzPriorityEndpoints'], ['https://qobuz.example.com']);
-    expect(result['amazonPriorityEndpoints'], ['https://amazon.example.com']);
-  });
+      final result = container.read(configProvider).value ?? {};
+      expect(result['tidalPriorityEndpoints'], ['https://tidal.example.com']);
+      expect(result['qobuzPriorityEndpoints'], ['https://qobuz.example.com']);
+      expect(result['amazonPriorityEndpoints'], [
+        'https://amazon.example.com',
+      ]);
+    },
+    skip:
+        'requires FlacCore native init (Go FFI shared library + '
+        'path_provider platform channel) — only available inside a real '
+        'app bundle on a device/emulator via integration_test, not a plain '
+        '`flutter test` unit-test process. See lib/main.dart:29-31 for the '
+        'only real init() call site.',
+  );
 }


### PR DESCRIPTION
## Summary

Adds a self-host/priority-endpoints config field to the mobile settings screen, part of the same effort as kushiemoon-dev/FLACidal-Core#3 and kushiemoon-dev/FLACidal#15 (see those for the fuller context: self-hosted endpoints were configured but never actually used).

- Three new config-map keys, mirroring the Core's exact JSON tag names (`tidalPriorityEndpoints`, `qobuzPriorityEndpoints`, `amazonPriorityEndpoints`) character-for-character, so the Core deserializes without translation.
- A minimal settings-page input per source, reusing an existing dialog widget (now parameterized by title). Deliberately **no** status/health rendering; that's a separate, later piece of work.
- Fixed a silent-failure bug on save (an uncaught exception if `FlacCore` failed to init, now surfaced via a SnackBar, matching the existing error-handling pattern elsewhere in this file).

## Known limitation: please read before merging

**This PR was written and reviewed entirely without a Flutter/Dart SDK available** (sandbox limitation). Nothing here has ever been run through `flutter analyze`, `flutter test`, `dart format`, or a real device/emulator. Verification was by careful, repeated manual code review only (checked twice: once during implementation, once during a final whole-branch review).

Also: the round-trip test for the new config keys is present but marked `skip:` with an honest reason (`FlacCore`'s native init needs a running app: FFI shared library + a `path_provider` platform channel, neither available in a plain `flutter test` process). It documents the intended behavior but proves nothing yet.

**Before merging, please run:**
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] `dart format --output=none --set-exit-if-changed lib test`
- [ ] A real device/emulator check that setting a priority endpoint actually round-trips to the Core config

---

Built with Claude Code. Given the SDK limitation, this PR carries less first-hand verification than the sibling PRs (kushiemoon-dev/FLACidal-Core#3, kushiemoon-dev/FLACidal#15); the checklist above is the gap between "should be correct by inspection" and actually confirmed.
