### PR TITLE
feat: extension permissions display + update-available badge

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: kushiemoon-dev/flacidal-core
-          ref: v0.19.0
+          ref: v0.21.0
           path: flacidal-core
           token: ${{ secrets.CORE_ACCESS_TOKEN }}
 

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: kushiemoon-dev/flacidal-core
-          ref: v0.19.0
+          ref: v0.21.0
           path: flacidal-core
           token: ${{ secrets.CORE_ACCESS_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 - **Extensions permissions disclosure** — The extensions page now shows an extension's declared `permissions` (storage access, file deletion, library re-enrichment, etc.) before install/activation, on both the Installed and Browse tabs, so users can make informed decisions about which extensions to trust.
 - **Update detection in Browse tab** — The Browse tab now distinguishes "Update available" from "Installed, up to date" for already-installed extensions by comparing the registry's version string against the locally installed version, matching desktop's behavior.
+- **Core dependency bump to v0.21.0** — this build also pulls in [flacidal-core v0.21.0](https://github.com/kushiemoon-dev/flacidal-core/releases/tag/v0.21.0): the new metadata-extension capability (structured track metadata supplied by extension plugins) is what makes the permissions and update-badge UI above meaningful, and separately, embedded covers now always get fetched over the network and written to the tag whenever a download job has a `CoverURL`, even with zero metadata extensions installed — previously this never fetched. That cover-art change is a deliberate upstream behavior change and affects every mobile user, not just extension users.
 
 ## v0.8.0-beta.10 — 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.8.0-beta.11 — 2026-08-27
+
+### New features
+- **Extensions permissions disclosure** — The extensions page now shows an extension's declared `permissions` (storage access, file deletion, library re-enrichment, etc.) before install/activation, on both the Installed and Browse tabs, so users can make informed decisions about which extensions to trust.
+- **Update detection in Browse tab** — The Browse tab now distinguishes "Update available" from "Installed, up to date" for already-installed extensions by comparing the registry's version string against the locally installed version, matching desktop's behavior.
+
 ## v0.8.0-beta.10 — 2026-08-27
 
 ### New features

--- a/lib/pages/extensions_page.dart
+++ b/lib/pages/extensions_page.dart
@@ -373,6 +373,11 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
                   ?.map((c) => c.toString())
                   .join(', ') ??
               '';
+          final permissions =
+              (manifest['permissions'] as List<dynamic>?)
+                  ?.map((p) => p.toString())
+                  .toList() ??
+              [];
 
           return Card(
             margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
@@ -389,7 +394,16 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
                 ),
               ),
               title: Text(name),
-              subtitle: Text('$author · v$version · $caps'),
+              subtitle: permissions.isEmpty
+                  ? Text('$author · v$version · $caps')
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text('$author · v$version · $caps'),
+                        Text('Permissions: ${permissions.join(", ")}'),
+                      ],
+                    ),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -531,6 +545,11 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
               final version = item['latestVersion'] as String? ?? '';
               final downloadURL = item['downloadURL'] as String? ?? '';
               final installed = installedIds.contains(id);
+              final permissions =
+                  (item['permissions'] as List<dynamic>?)
+                      ?.map((p) => p.toString())
+                      .toList() ??
+                  [];
 
               return Card(
                 margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
@@ -538,9 +557,10 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
                   leading: const CircleAvatar(child: Icon(Icons.extension)),
                   title: Text(name),
                   subtitle: Text(
-                    '$desc${version.isNotEmpty ? '\nv$version' : ''}',
+                    '$desc${version.isNotEmpty ? '\nv$version' : ''}'
+                    '${permissions.isNotEmpty ? '\nPermissions: ${permissions.join(", ")}' : ''}',
                   ),
-                  isThreeLine: desc.isNotEmpty,
+                  isThreeLine: desc.isNotEmpty || permissions.isNotEmpty,
                   trailing: installed
                       ? const Chip(label: Text('Installed'))
                       : _installingIds.contains(id)

--- a/lib/pages/extensions_page.dart
+++ b/lib/pages/extensions_page.dart
@@ -570,7 +570,13 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
                     '${permissions.isNotEmpty ? '\nPermissions: ${permissions.join(", ")}' : ''}',
                   ),
                   isThreeLine: desc.isNotEmpty || permissions.isNotEmpty,
-                  trailing: hasUpdate
+                  trailing: _installingIds.contains(id)
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : hasUpdate
                       ? FilledButton(
                           onPressed: downloadURL.isNotEmpty
                               ? () => _installExtension(id, downloadURL)
@@ -579,12 +585,6 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
                         )
                       : installed
                       ? const Chip(label: Text('Installed'))
-                      : _installingIds.contains(id)
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
                       : FilledButton(
                           onPressed: downloadURL.isNotEmpty
                               ? () => _installExtension(id, downloadURL)

--- a/lib/pages/extensions_page.dart
+++ b/lib/pages/extensions_page.dart
@@ -484,12 +484,16 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
       );
     }
 
-    final installedIds = _installed.map((e) {
-      final m =
-          (e as Map<String, dynamic>)['manifest'] as Map<String, dynamic>? ??
-          {};
-      return m['id'] as String? ?? '';
-    }).toSet();
+    final installedVersions = {
+      for (final e in _installed)
+        ((e as Map<String, dynamic>)['manifest'] as Map<String, dynamic>? ??
+                        {})['id']
+                    as String? ??
+                '':
+            ((e)['manifest'] as Map<String, dynamic>? ?? {})['version']
+                as String? ??
+            '',
+    };
 
     final filtered = _filteredRegistry;
 
@@ -544,7 +548,12 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
               final desc = item['description'] as String? ?? '';
               final version = item['latestVersion'] as String? ?? '';
               final downloadURL = item['downloadURL'] as String? ?? '';
-              final installed = installedIds.contains(id);
+              final installedVersion = installedVersions[id];
+              final installed = installedVersion != null;
+              final hasUpdate =
+                  installed &&
+                  installedVersion != version &&
+                  version.isNotEmpty;
               final permissions =
                   (item['permissions'] as List<dynamic>?)
                       ?.map((p) => p.toString())
@@ -561,7 +570,14 @@ class _ExtensionsPageState extends ConsumerState<ExtensionsPage>
                     '${permissions.isNotEmpty ? '\nPermissions: ${permissions.join(", ")}' : ''}',
                   ),
                   isThreeLine: desc.isNotEmpty || permissions.isNotEmpty,
-                  trailing: installed
+                  trailing: hasUpdate
+                      ? FilledButton(
+                          onPressed: downloadURL.isNotEmpty
+                              ? () => _installExtension(id, downloadURL)
+                              : null,
+                          child: const Text('Update'),
+                        )
+                      : installed
                       ? const Chip(label: Text('Installed'))
                       : _installingIds.contains(id)
                       ? const SizedBox(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -556,10 +556,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1097,26 +1097,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.8.0-beta.9+25
+version: 0.8.0-beta.11+26
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
## Summary

Mobile side of the community extension ecosystem (companion to FLACidal-Core #4 and flacidal-extensions #1):

- Installed and Browse tabs now show an extension's `permissions` before install/activation (previously never read or shown)
- Browse tab distinguishes "Update available" from "Installed, up to date" by comparing registry vs. installed version
- `pubspec.yaml` bumped to `0.8.0-beta.11+26`, CI refs bumped to Core `v0.21.0`

## Fixed during whole-branch review
- The new "Update" button had no in-flight state, so a second tap could race a concurrent install RPC. Hoisted the loading-spinner check above `hasUpdate`/`installed` in the trailing branching.
- CHANGELOG entry now references Core v0.21.0's shipped changes (the metadata capability itself, plus a CoverURL/TagFile behavior change that ships bundled in this build for every user, not just extension users)

## Known gap
- `libflacidal.so` rebuild from Core v0.21.0 is deferred to this repo's CI (`android-build.yml`/`ios-build.yml`), no local Android NDK toolchain was available to do it in this session. On-device manual verification (install `deezer-metadata`, confirm permissions display, trigger a download with a known ISRC, re-enrich a library file, publish a point release and confirm the Update badge) is explicitly non-automatable and still needs to happen before this ships.

## Test plan
- [x] `flutter analyze` clean on changed files
- [x] `flutter test`: all pass
- [ ] Manual on-device verification (blocked on CI rebuild of `libflacidal.so`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via subagent-driven-development.
