### PR TITLE
fix: persist debug keystore across CI runs

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -42,6 +42,16 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
 
+      # The app is intentionally signed with the debug key (android/app/build.gradle.kts),
+      # not a real release key -- this repo distributes betas via GitHub Releases, not the
+      # Play Store. Without this, every CI run generates a fresh throwaway debug.keystore,
+      # so each release's signature differs from the last and Android refuses to install
+      # an update over the previous one (INSTALL_FAILED_UPDATE_INCOMPATIBLE).
+      - name: Restore persistent debug keystore
+        run: |
+          mkdir -p ~/.android
+          echo "${{ secrets.ANDROID_DEBUG_KEYSTORE }}" | base64 -d > ~/.android/debug.keystore
+
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:


### PR DESCRIPTION
## Summary

Testing v0.8.0-beta.11 hit `INSTALL_FAILED_UPDATE_INCOMPATIBLE`; the release APK's signature didn't match the previously-installed beta. Root cause: `android/app/build.gradle.kts` intentionally signs with the debug key (this repo distributes betas via GitHub Releases, not the Play Store), but `Android Build & Release` never persisted a debug keystore across runs; each CI run's ephemeral runner generates its own throwaway one, so every release has been signed differently from the last, silently breaking in-place updates for every beta so far.

Fix: restore a fixed debug keystore (stored as the `ANDROID_DEBUG_KEYSTORE` repo secret, base64-encoded) before the build, so consecutive releases share the same signature and install as updates.

## Test plan
- [x] `adb install -r` on beta.11 over an existing install reproduced the exact failure (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`)
- [ ] Next tagged release after this merges should install cleanly over beta.11 without an uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)
